### PR TITLE
Reduced Access to Improve Safety

### DIFF
--- a/transfer_qual_codes_template.ipynb
+++ b/transfer_qual_codes_template.ipynb
@@ -69,10 +69,7 @@
    "outputs": [],
    "source": [
     "# If modifying these scopes, delete the file token.json.\n",
-    "SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly',\n",
-    "         'https://www.googleapis.com/auth/drive',\n",
-    "        'https://www.googleapis.com/auth/drive.readonly',\n",
-    "        'https://www.googleapis.com/auth/drive.file']\n",
+    "SCOPES = ['https://www.googleapis.com/auth/drive.readonly']\n",
     "\n",
     "creds = None\n",
     "# The file token.json stores the user's access and refresh tokens, and is\n",


### PR DESCRIPTION
Reduced the permissions needed for this app to be readonly because this script doesn't need to be able to create, edit and delete files. This will help make the tool safer and prevent folks from accidentally modifying their drive.