### PR TITLE
Bug Fix

### DIFF
--- a/transfer_qual_codes_template.ipynb
+++ b/transfer_qual_codes_template.ipynb
@@ -123,7 +123,7 @@
     "file_id = \"\" # something like \"15dR04q_whT11lHKDSsSVFkYsxoC8_wKCDUb0eh9vyvc\"\n",
     "result = service.comments().list(fileId=file_id, fields=\"*\").execute()\n",
     "for comment in result['comments']:\n",
-    "    if comment['resolved']: continue\n",
+    "    if comment.get('resolved'): continue\n",
     "    print(comment['author']['displayName'], comment['anchor'])\n",
     "    print(comment)\n",
     "    print(\"\")"


### PR DESCRIPTION
Fix bug where comment doesn't have resolved field. 

I found if you resolve and re-open a comment, the comment object's resolved field isn't changed back from True to False but rather simply removed, leading to a KeyError.